### PR TITLE
feat(cart): redesign cart page with responsive layout and order summary

### DIFF
--- a/components/cart-page-component/CartSection.tsx
+++ b/components/cart-page-component/CartSection.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect } from "react";
 import Link from "next/link";
 import Image from "next/image";
+import { useRouter } from "next/router";
 import { useAuth } from "@/context/AuthContext";
 import { useCart } from "@/context/CartContext";
 import { useFavorites } from "@/context/FavoritesContext";
@@ -16,6 +17,7 @@ interface CartSectionProps {
 }
 
 const CartSection: React.FC<CartSectionProps> = ({ isGuest = false }) => {
+  const router = useRouter();
   const { isAuthenticated } = useAuth();
   const { cart, updateQuantity, removeFromCart, getCartTotal } = useCart();
   const {
@@ -29,19 +31,30 @@ const CartSection: React.FC<CartSectionProps> = ({ isGuest = false }) => {
   const [swipeX, setSwipeX] = useState<number>(0);
   const [startX, setStartX] = useState<number | null>(null);
   const swipedRef = useRef<HTMLDivElement | null>(null);
+  const cardRefs = useRef<{ [key: string]: HTMLDivElement | null }>({});
   const [alerts, setAlerts] = useState<AlertItem[]>([]);
+
+  const gridCols = "grid-cols-[80px_minmax(200px,1.5fr)_1fr_1fr_1fr_80px]";
+
+  const [didSwipe, setDidSwipe] = useState(false);
 
   const handleTouchStart = (e: React.TouchEvent, id: string) => {
     setStartX(e.touches[0].clientX);
     setSwipedItem(id);
+    setDidSwipe(false); // reset
   };
 
   const handleTouchMove = (e: React.TouchEvent, id: string) => {
     if (startX === null || swipedItem !== id) return;
 
     const deltaX = e.touches[0].clientX - startX;
+
+    if (deltaX < -10) {
+      setDidSwipe(true); // ✅ mark as swipe
+    }
+
     if (deltaX < 0) {
-      setSwipeX(Math.max(deltaX, -100)); // limit left swipe
+      setSwipeX(Math.max(deltaX, -100));
     }
   };
 
@@ -52,13 +65,24 @@ const CartSection: React.FC<CartSectionProps> = ({ isGuest = false }) => {
       setSwipeX(0);
       setSwipedItem(null);
     }
+
     setStartX(null);
+  };
+
+  const handleCheckout = () => {
+    router.push(
+      isAuthenticated ? "/customer/my-account/checkout" : "/customer/checkout",
+    );
+  };
+
+  const handleContinueShopping = () => {
+    router.push("/products");
   };
 
   const showAlert = (
     message: string,
     type: "success" | "error",
-    scope: "local" | "global" = "local"
+    scope: "local" | "global" = "local",
   ) => {
     if (scope === "local") {
       const id = Date.now() + Math.random();
@@ -86,200 +110,518 @@ const CartSection: React.FC<CartSectionProps> = ({ isGuest = false }) => {
     };
   }, [swipedRef]);
 
-  return (
-    <div className="flex-1 overflow-y-auto">
-      {cart.length === 0 ? (
-        <div className="text-center py-8 flex flex-col gap-2 px-7">
-          <ShoppingCart size={48} className="mx-auto text-gray-300" />
-          <p className="text-gray-500 text-lg font-semibold">
-            Your cart is empty.
-          </p>
-          <Button
-            variant="yellow"
-            className="rounded-full py-5 mt-4 text-base"
-            onClick={() => (window.location.href = "/products")}
-          >
-            Continue Shopping
-          </Button>
-        </div>
-      ) : (
-        <div>
-          <h1 className="text-2xl font-semibold mb-4">
-            {isAuthenticated ? "Your Shopping Cart" : "Your Cart"}
-          </h1>
-          {cart.map((item: CartItem) => (
-            <div
-              key={item.product_id}
-              className="relative w-full mb-4 overflow-hidden"
-            >
-              {/* Red background */}
-              <div className="absolute top-0 right-0 bottom-0 left-0  flex flex-row justify-end items-center z-0">
-                <div className="bg-white"></div>
-                <div
-                  className=" bg-red-600 h-24 w-25 pl-2 flex justify-center items-center"
-                  ref={swipedRef}
-                  onClick={() => removeFromCart(item.product_id)}
-                >
-                  <Trash2
-                    size={20}
-                    className="text-white"
-                    style={{
-                      transform:
-                        swipedItem === item.product_id
-                          ? `translateX(${swipeX / 22}px)`
-                          : "translateX(0)",
-                    }}
-                  />
-                </div>
-              </div>
-              <div
-                key={item.product_id}
-                className="flex items-center gap-3 z-10 relative bg-white h-40"
-                onTouchStart={(e) => handleTouchStart(e, item.product_id)}
-                onTouchMove={(e) => handleTouchMove(e, item.product_id)}
-                onTouchEnd={handleTouchEnd}
-                style={{
-                  transform:
-                    swipedItem === item.product_id
-                      ? `translateX(${swipeX}px)`
-                      : "translateX(0)",
-                  transition: "transform 0.3s cubic-bezier(0.25, 1.5, 0.5, 1)",
-                }}
-              >
-                <div className="w-20 h-28 flex-shrink-0 overflow-hidden ml-2">
-                  <Image
-                    src={item.image_url}
-                    alt={item.name}
-                    width={60}
-                    height={60}
-                    className="object-cover  w-full h-full"
-                  />
-                </div>
-                <div className="flex-1">
-                  <Link
-                    href={`/products/${item.slug}`}
-                    className="block w-full"
-                  >
-                    <h3 className="font-semibold text-gray-900 text-sm lg:text-base mb-1 hover:text-yellow-600">
-                      {item.name}
-                    </h3>
-                  </Link>
+  const FREE_SHIPPING_THRESHOLD = 50;
+  const cartTotal = getCartTotal();
+  const SHIPPING_FEE = 15;
+  const isFreeShipping = cartTotal >= FREE_SHIPPING_THRESHOLD;
+  const shippingFee = isFreeShipping ? 0 : SHIPPING_FEE;
+  const finalTotal = cartTotal + shippingFee;
 
-                  <p className="text-green-600 text-base font-semibold">
-                    ${((item.price || 0) * item.quantity).toFixed(2)}
-                  </p>
-                  <Button
-                    className="flex flex-col"
-                    variant="ghost"
-                    size="icon-sm"
-                    onClick={async (e) => {
-                      removeFromCart(item.product_id);
-                      e.stopPropagation();
-                      try {
-                        if (isFavorite(item.product_id)) {
-                          await removeFavorite(item.product_id);
-                          showAlert(
-                            "Removed from favorites",
-                            "success",
-                            "local"
-                          );
-                        } else {
-                          await addFavorite(item.product_id);
-                          // Show different message for guest vs logged-in
-                          if (isAuthenticated) {
-                            showAlert(
-                              "Added to favorites!",
-                              "success",
-                              "local"
-                            );
-                          } else {
-                            showAlert(
-                              "Added to favorites! Log in to sync",
-                              "success",
-                              "local"
-                            );
-                          }
-                        }
-                      } catch (err) {
-                        console.error("Error updating favorites:", err);
-                        showAlert("Failed to update favorite", "error");
-                      }
-                    }}
-                  >
-                    <div className="flex flex-row w-30">
-                      <Heart
-                        className={`transition-colors duration-200 ${
-                          isFavorite(item.product_id)
-                            ? "text-yellow-400"
-                            : "text-gray-300"
-                        }`}
-                        fill={
-                          isFavorite(item.product_id) ? "currentColor" : "none"
-                        }
-                      />
-                      <span>Save for later</span>
-                    </div>
-                  </Button>
-                  <div className="flex justify-between items-center gap-2 mt-2">
-                    <div className="flex flex-row gap-2">
-                      <button
-                        onClick={() =>
-                          updateQuantity(
-                            item.product_id,
-                            Math.max(0, item.quantity - 1)
-                          )
-                        }
-                        className="p-3 rounded-full text-gray-700 border-none  hover:bg-gray-200 transition-colors duration-200 cursor-pointer"
-                      >
-                        <Minus size={15} />
-                      </button>
-                      <span className="flex justify-center text-sm font-medium w-4 text-center items-center text-gray-700">
-                        {item.quantity}
-                      </span>
-                      <button
-                        onClick={() =>
-                          updateQuantity(item.product_id, item.quantity + 1)
-                        }
-                        className="p-3 rounded-full text-gray-700 border-none hover:bg-gray-200 transition-colors duration-200 cursor-pointer"
-                      >
-                        <Plus size={15} />
-                      </button>
-                    </div>
-                    <button
-                      onClick={() => removeFromCart(item.product_id)}
-                      className="ml-2 p-2 rounded-full hover:bg-gray-200 transition-colors duration-200 mr-4  cursor-pointer"
-                      aria-label="Remove from cart"
+  const remainingForFreeShipping = Math.max(
+    FREE_SHIPPING_THRESHOLD - cartTotal,
+    0,
+  );
+
+  return (
+    <div className="lg:flex lg:gap-8 lg:items-start">
+      <div className="flex-1 overflow-y-auto">
+        {cart.length === 0 ? (
+          <div className="text-center py-8 flex flex-col gap-2 px-7">
+            <ShoppingCart size={48} className="mx-auto text-gray-300" />
+            <p className="text-gray-500 text-lg font-semibold">
+              Your cart is empty.
+            </p>
+            <Button
+              variant="yellow"
+              className="rounded-full py-5 mt-4 text-base"
+              onClick={() => (window.location.href = "/products")}
+            >
+              Continue Shopping
+            </Button>
+          </div>
+        ) : (
+          <div className="h-full pb-50 lg:pb-0">
+            <div className="flex flex-col lg:flex-row gap-3 lg:items-baseline mb-3">
+              <h2 className="text-2xl font-semibold text-yellow-700 leading-tight">
+                {isAuthenticated ? "Your Shopping Cart" : "Your Cart"}
+              </h2>
+              <p className="text-base lg:text-lg text-gray-600 leading-tight">
+                {isAuthenticated
+                  ? "Review your items before checkout"
+                  : "Sign in to view and manage your cart"}
+              </p>
+              <span className="text-lg font-bold text-yellow-600">
+                ({cart.reduce((acc, i) => acc + i.quantity, 0)} items)
+              </span>
+            </div>
+            <div className="relative lg:h-[calc(100vh-220px)] lg:overflow-y-auto">
+              <div
+                className={`hidden sticky lg:grid ${gridCols} px-5 py-5 text-sm font-semibold text-gray-600 bg-gray-100 rounded-t-lg mt-3 top-0 z-20`}
+              >
+                <div>Product</div>
+                <div className="text-center">Name</div>
+                <div>Price</div>
+                <div className="pl-6">Quantity</div>
+                <div>Sub Total</div>
+                <div className="text-end">Delete</div>
+              </div>
+
+              {cart.map((item: CartItem) => (
+                <div key={item.product_id} className="relative overflow-hidden">
+                  <div className="relative hidden lg:block ">
+                    <div
+                      className={`flex flex-col lg:grid ${gridCols} items-center z-10 relative bg-white border-b border-gray-300 `}
+                      onTouchStart={(e) => handleTouchStart(e, item.product_id)}
+                      onTouchMove={(e) => handleTouchMove(e, item.product_id)}
+                      onTouchEnd={handleTouchEnd}
+                      style={{
+                        transform:
+                          swipedItem === item.product_id
+                            ? `translateX(${swipeX}px)`
+                            : "translateX(0)",
+                        transition:
+                          "transform 0.3s cubic-bezier(0.25, 1.5, 0.5, 1)",
+                      }}
                     >
-                      <Trash2
-                        size={18}
-                        className="hidden lg:block text-gray-500"
-                      />
-                    </button>
+                      <div className="w-20 h-28 flex-row overflow-hidden">
+                        <Link href={`/products/${item.slug}`}>
+                          <Image
+                            src={item.image_url}
+                            alt={item.name}
+                            width={60}
+                            height={60}
+                            className="object-cover w-full h-full hover:border-2 hover:border-yellow-500"
+                          />
+                        </Link>
+                      </div>
+                      <div className="w-full pl-8">
+                        <Link href={`/products/${item.slug}`}>
+                          <h3 className="font-semibold text-gray-900 text-sm lg:text-base  hover:text-yellow-600">
+                            {item.name}
+                          </h3>
+                        </Link>
+                        <Button
+                          className="flex flex-row w-full justify-start px-0 hover:bg-transparent"
+                          variant="ghost"
+                          onClick={async (e) => {
+                            e.stopPropagation();
+                            try {
+                              if (isFavorite(item.product_id)) {
+                                await removeFavorite(item.product_id);
+                                showAlert(
+                                  "Removed from favorites",
+                                  "success",
+                                  "local",
+                                );
+                              } else {
+                                await addFavorite(item.product_id);
+                                // Show different message for guest vs logged-in
+                                if (isAuthenticated) {
+                                  removeFromCart(item.product_id);
+                                  showAlert(
+                                    "Added to favorites!",
+                                    "success",
+                                    "local",
+                                  );
+                                } else {
+                                  removeFromCart(item.product_id);
+                                  showAlert(
+                                    "Added to favorites! Log in to sync",
+                                    "success",
+                                    "local",
+                                  );
+                                }
+                              }
+                            } catch (err) {
+                              console.error("Error updating favorites:", err);
+                              showAlert("Failed to update favorite", "error");
+                            }
+                          }}
+                        >
+                          <div className="flex items-center gap-2">
+                            <Heart
+                              className={`transition-colors duration-200 ${
+                                isFavorite(item.product_id)
+                                  ? "text-yellow-400"
+                                  : "text-gray-300"
+                              }`}
+                              fill={
+                                isFavorite(item.product_id)
+                                  ? "currentColor"
+                                  : "none"
+                              }
+                            />
+                            <span>
+                              {isFavorite(item.product_id)
+                                ? "In favorites"
+                                : "Save for later"}
+                            </span>
+                          </div>
+                        </Button>
+                      </div>
+
+                      <p>${item.price || 0}</p>
+
+                      <div className="flex">
+                        <div className="flex flex-row gap-2">
+                          <button
+                            onClick={() =>
+                              updateQuantity(
+                                item.product_id,
+                                Math.max(0, item.quantity - 1),
+                              )
+                            }
+                            className="p-3 rounded-full text-gray-700 border-none  hover:bg-gray-200 transition-colors duration-200 cursor-pointer"
+                          >
+                            <Minus size={15} />
+                          </button>
+                          <span className="flex justify-center text-sm font-medium w-4 text-center items-center text-gray-700">
+                            {item.quantity}
+                          </span>
+                          <button
+                            onClick={() =>
+                              updateQuantity(item.product_id, item.quantity + 1)
+                            }
+                            className="p-3 rounded-full text-gray-700 border-none hover:bg-gray-200 transition-colors duration-200 cursor-pointer"
+                          >
+                            <Plus size={15} />
+                          </button>
+                        </div>
+                      </div>
+                      <div className="text-green-600 text-base font-semibold">
+                        {" "}
+                        ${((item.price || 0) * item.quantity).toFixed(2)}
+                      </div>
+                      <Button
+                        variant="ghost"
+                        onClick={() => removeFromCart(item.product_id)}
+                        className="rounded-full transition-colors duration-200 cursor-pointer"
+                        aria-label="Remove from cart"
+                      >
+                        <Trash2
+                          size={18}
+                          className="hidden lg:block text-gray-500"
+                        />
+                      </Button>
+                    </div>
+                  </div>
+
+                  {/* mobile  */}
+                  <div className="block lg:hidden w-full mb-4">
+                    {/* Red background */}
+                    {swipedItem === item.product_id && (
+                      <div
+                        className="absolute inset-y-0 right-0 w-24 h-35 bg-red-600 flex justify-center items-center z-0"
+                        ref={swipedRef}
+                        onClick={() => {
+                          removeFromCart(item.product_id);
+                          setSwipeX(0);
+                          setSwipedItem(null);
+                        }}
+                      >
+                        <Trash2
+                          size={20}
+                          className="text-white ml-2"
+                          style={{
+                            transform:
+                              swipedItem === item.product_id
+                                ? `translateX(${swipeX / 22}px)`
+                                : "translateX(0)",
+                          }}
+                        />
+                      </div>
+                    )}
+
+                    <div
+                      key={item.product_id}
+                      ref={(el) => {
+                        if (el) {
+                          cardRefs.current[item.product_id] = el;
+                        }
+                      }}
+                      className="flex items-center gap-3 z-10 relative bg-white h-35"
+                      onTouchStart={(e) => handleTouchStart(e, item.product_id)}
+                      onTouchMove={(e) => handleTouchMove(e, item.product_id)}
+                      onTouchEnd={handleTouchEnd}
+                      style={{
+                        transform:
+                          swipedItem === item.product_id
+                            ? `translateX(${swipeX}px)`
+                            : "translateX(0)",
+                        transition:
+                          "transform 0.3s cubic-bezier(0.25, 1.5, 0.5, 1)",
+                      }}
+                    >
+                      <div className="w-20 h-28 flex-shrink-0 overflow-hidden">
+                        <Image
+                          src={item.image_url}
+                          alt={item.name}
+                          width={60}
+                          height={60}
+                          className="object-cover  w-full h-full"
+                        />
+                      </div>
+                      <div className="flex-1">
+                        <Link
+                          href={`/products/${item.slug}`}
+                          className="block w-full"
+                        >
+                          <h3 className="font-semibold text-gray-900 text-sm lg:text-base mb-1 hover:text-yellow-600">
+                            {item.name}
+                          </h3>
+                        </Link>
+
+                        <Button
+                          className="p-0"
+                          variant="ghost"
+                          onClick={async (e) => {
+                            e.stopPropagation();
+                            try {
+                              if (isFavorite(item.product_id)) {
+                                await removeFavorite(item.product_id);
+                                showAlert(
+                                  "Removed from favorites",
+                                  "success",
+                                  "local",
+                                );
+                              } else {
+                                await addFavorite(item.product_id);
+                                // Show different message for guest vs logged-in
+                                if (isAuthenticated) {
+                                  removeFromCart(item.product_id);
+                                  showAlert(
+                                    "Added to favorites!",
+                                    "success",
+                                    "local",
+                                  );
+                                } else {
+                                  removeFromCart(item.product_id);
+                                  showAlert(
+                                    "Added to favorites! Log in to sync",
+                                    "success",
+                                    "local",
+                                  );
+                                }
+                              }
+                            } catch (err) {
+                              console.error("Error updating favorites:", err);
+                              showAlert("Failed to update favorite", "error");
+                            }
+                          }}
+                        >
+                          <div className="flex flex-row gap-2">
+                            <Heart
+                              className={`transition-colors duration-200 ${
+                                isFavorite(item.product_id)
+                                  ? "text-yellow-400"
+                                  : "text-gray-300"
+                              }`}
+                              fill={
+                                isFavorite(item.product_id)
+                                  ? "currentColor"
+                                  : "none"
+                              }
+                            />
+                            <span>
+                              {isFavorite(item.product_id)
+                                ? "In favorites"
+                                : "Save for later"}
+                            </span>
+                          </div>
+                        </Button>
+
+                        <p className="text-green-600 text-base font-semibold">
+                          ${((item.price || 0) * item.quantity).toFixed(2)}
+                        </p>
+
+                        <div className="flex justify-between items-center gap-2 mt-2">
+                          <div className="flex flex-row gap-2">
+                            <button
+                              onClick={() =>
+                                updateQuantity(
+                                  item.product_id,
+                                  Math.max(0, item.quantity - 1),
+                                )
+                              }
+                              className="p-3 rounded-full text-gray-700 border-none  hover:bg-gray-200 transition-colors duration-200 cursor-pointer"
+                            >
+                              <Minus size={15} />
+                            </button>
+                            <span className="flex justify-center text-sm font-medium w-4 text-center items-center text-gray-700">
+                              {item.quantity}
+                            </span>
+                            <button
+                              onClick={() =>
+                                updateQuantity(
+                                  item.product_id,
+                                  item.quantity + 1,
+                                )
+                              }
+                              className="p-3 rounded-full text-gray-700 border-none hover:bg-gray-200 transition-colors duration-200 cursor-pointer"
+                            >
+                              <Plus size={15} />
+                            </button>
+                          </div>
+                          <button
+                            onClick={() => removeFromCart(item.product_id)}
+                            className="ml-2 p-2 rounded-full hover:bg-gray-200 transition-colors duration-200 mr-4  cursor-pointer"
+                            aria-label="Remove from cart"
+                          >
+                            <Trash2
+                              size={18}
+                              className="hidden lg:block text-gray-500"
+                            />
+                          </button>
+                        </div>
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
+              ))}
             </div>
-          ))}
-        </div>
-      )}
+          </div>
+        )}
 
-      {/* Cart Footer */}
-      {cart.length > 0 && (
-        <div className="pt-4 px-4 mb-4">
-          <div className="flex justify-between items-center mb-4">
-            <span className="text-lg font-semibold">Total:</span>
+        {/* Cart Footer for mobile only*/}
+        {cart.length > 0 && (
+          <div className="block lg:hidden fixed lg:left-1/2 lg:-translate-x-1/2  bottom-0 left-0 right-0  w-full bg-white lg:py-4 max-w-xl p-3  z-40">
+            {/* Free shipping message */}
+            {cartTotal < FREE_SHIPPING_THRESHOLD ? (
+              <p className="text-sm text-gray-600 text-center mb-2">
+                Spend{" "}
+                <span className="font-semibold text-yellow-600">
+                  ${remainingForFreeShipping.toFixed(2)}
+                </span>{" "}
+                more to get <span className="font-semibold">FREE shipping</span>
+              </p>
+            ) : (
+              <p className="text-sm text-green-600 font-medium text-center mb-2">
+                🎉 You’ve unlocked{" "}
+                <span className="font-semibold">FREE shipping</span>
+              </p>
+            )}
+            <div className="flex justify-between">
+              <span className="text-base">
+                Subtotal ({cart.reduce((acc, i) => acc + i.quantity, 0)} items)
+              </span>
+              <span className="text-base font-semibold">
+                ${cartTotal.toFixed(2)}
+              </span>
+            </div>
+            <div className="space-y-3 text-sm">
+              <div className="flex justify-between text-base">
+                <span className="text-base">Delivery</span>
+                <span>
+                  {" "}
+                  {isFreeShipping ? (
+                    <span className="text-green-600 text-base">FREE</span>
+                  ) : (
+                    <span className="text-base font-semibold">
+                      {" "}
+                      ${shippingFee.toFixed(2)}
+                    </span>
+                  )}
+                </span>
+              </div>
+              <hr />
+              <span className="text-xl font-semibold">Total: </span>
+              <span className="text-xl font-bold text-yellow-600">
+                ${finalTotal.toFixed(2)}
+              </span>
+            </div>
+            <div className="flex flex-col gap-2 mt-2">
+              <Button
+                onClick={handleCheckout}
+                className="min-w-80 rounded-full w-full text-lg"
+              >
+                Checkout
+              </Button>
+              <Button
+                variant="ghost"
+                onClick={handleContinueShopping}
+                className="min-w-80 rounded-full w-full underline text-base text-center text-gray-600 hover:text-yellow-600  transition-colors"
+              >
+                Continue shopping
+              </Button>
+            </div>
+          </div>
+        )}
+        <CustomAlert
+          alerts={alerts}
+          onClose={(id) => {
+            setAlerts((prev) => prev.filter((alert) => alert.id !== id));
+          }}
+        />
+      </div>
+
+      {/* Order Summary — desktop only */}
+      <div className="hidden lg:block w-80 flex-shrink-0 sticky top-6 mt-14">
+        <div className="border border-gray-200 rounded-2xl p-6 bg-white shadow-sm">
+          <h3 className="text-lg font-bold text-gray-800 mb-5">
+            Order Summary
+          </h3>
+          {/* Free shipping message */}
+          {cartTotal < FREE_SHIPPING_THRESHOLD ? (
+            <p className="text-[0.8rem] text-gray-600 text-center mb-5">
+              Spend{" "}
+              <span className="font-semibold text-yellow-600">
+                ${remainingForFreeShipping.toFixed(2)}
+              </span>{" "}
+              more to get <span className="font-semibold">FREE shipping</span>
+            </p>
+          ) : (
+            <p className="text-sm text-green-600 font-medium text-center mb-5">
+              🎉 You’ve unlocked{" "}
+              <span className="font-semibold">FREE shipping</span>
+            </p>
+          )}
+          <div className="space-y-3 text-lg text-gray-600">
+            <div className="flex justify-between">
+              <span>
+                Subtotal ({cart.reduce((acc, i) => acc + i.quantity, 0)} items)
+              </span>
+              <span className="font-medium text-gray-800">
+                ${getCartTotal().toFixed(2)}
+              </span>
+            </div>
+            <div className="flex justify-between">
+              <span>Delivery fee</span>
+              <span className="font-medium">
+                {" "}
+                {isFreeShipping ? (
+                  <span className="text-green-600 text-base">FREE</span>
+                ) : (
+                  <span className="text-base"> ${shippingFee.toFixed(2)}</span>
+                )}
+              </span>
+            </div>
+            <div className="flex justify-between">
+              <span>Tax</span>
+              <span className="font-medium text-gray-800">—</span>
+            </div>
+          </div>
+
+          <div className="border-t border-gray-200 my-4" />
+
+          <div className="flex justify-between items-center mb-5">
+            <span className="text-base font-bold text-gray-800">Total</span>
             <span className="text-xl font-bold text-yellow-600">
-              ${getCartTotal().toFixed(2)}
+              ${finalTotal.toFixed(2)}
             </span>
           </div>
+
+          <Button onClick={handleCheckout} className="rounded-full w-full">
+            Checkout
+          </Button>
+
+          <Link
+            href="/products"
+            className="block text-center text-sm text-gray-600 hover:text-yellow-600 mt-3 transition-colors underline"
+          >
+            Continue Shopping
+          </Link>
         </div>
-      )}
-      <CustomAlert
-        alerts={alerts}
-        onClose={(id) => {
-          setAlerts((prev) => prev.filter((alert) => alert.id !== id));
-        }}
-      />
+      </div>
     </div>
   );
 };

--- a/components/pages/CartPage.tsx
+++ b/components/pages/CartPage.tsx
@@ -12,7 +12,7 @@ import { ShoppingCart, Minus, Plus, Trash2 } from "lucide-react";
 import CartSection from "@/components/cart-page-component/CartSection";
 
 const CartPage = () => {
-   const { userId, logout } = useAuth();
+  const { userId, logout } = useAuth();
   const [userName, setUserName] = useState<string | null>(null);
 
   useEffect(() => {
@@ -32,12 +32,11 @@ const CartPage = () => {
     <div>
       <NotificationBar />
       <Navbar />
-      <div className="max-w-3xl mx-auto px-4 py-8">
+      <div className="w-full mx-auto px-4 py-8">
         <CartSection />
       </div>
     </div>
   );
 };
-
 
 export default CartPage;

--- a/components/pages/GuestCartPage.tsx
+++ b/components/pages/GuestCartPage.tsx
@@ -20,15 +20,11 @@ import {
 import CartSection from "@/components/cart-page-component/CartSection";
 
 const GuestCartPage = () => {
-
-
-  
-
   return (
     <div>
       <NotificationBar />
       <Navbar />
-      <div className="max-w-3xl mx-auto px-4 py-8">
+      <div className="w-full mx-auto px-4 py-8">
         <CartSection />
       </div>
     </div>

--- a/components/product-slug-page-components/AddToCartDialog.tsx
+++ b/components/product-slug-page-components/AddToCartDialog.tsx
@@ -28,7 +28,7 @@ export default function AddToCartDialog({
 
   const handleViewMyCart = () => {
     router.push(
-      isAuthenticated ? "/customer/my-account/cart" : "/customer/cart"
+      isAuthenticated ? "/customer/my-account/cart" : "/customer/cart",
     );
   };
 
@@ -123,7 +123,7 @@ export default function AddToCartDialog({
           <Button
             variant="ghost"
             onClick={onClose}
-            className="w-full py-3 text-base font-semibold rounded-full hover:bg-transparent underline underline-offset-3 decoration-1"
+            className="w-full py-3 text-base font-semibold rounded-full hover:bg-transparent underline underline-offset-3 decoration-1 text-gray-600"
           >
             Continue Shopping
           </Button>

--- a/components/wishlist-page-components/FavoriteProductsList.tsx
+++ b/components/wishlist-page-components/FavoriteProductsList.tsx
@@ -1,9 +1,24 @@
 import Image from "next/image";
+import axios from "axios";
 import { useRouter } from "next/router";
+import { useState } from "react";
 import { useAuth } from "@/context/AuthContext";
+
+import { useCart } from "@/context/CartContext";
 import { useFavorites } from "@/context/FavoritesContext";
-import { Heart } from "lucide-react";
+import {
+  ChevronLeft,
+  ChevronRight,
+  Heart,
+  Wheat,
+  Milk,
+  Bean,
+  Egg,
+} from "lucide-react";
 import Button from "@/components/ui/Button";
+import DrawerPanel from "@/components/DrawerPanel";
+import AddToCartDialog from "@/components/product-slug-page-components/AddToCartDialog";
+import CustomAlert from "@/components/ui/CustomAlert";
 
 interface FavoriteProduct {
   product_id: string;
@@ -24,70 +39,160 @@ export default function FavoriteProductsList({
   removeFavorite,
 }: Props) {
   const router = useRouter();
+  const { addToCart } = useCart();
   const { isFavorite } = useFavorites();
+  const [selectedProduct, setSelectedProduct] =
+    useState<FavoriteProduct | null>(null);
+  const [selectedQuantity, setSelectedQuantity] = useState(1);
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const [showDialog, setShowDialog] = useState(false);
 
   const handleProductClick = (slug: string) => {
     router.push(`/products/${slug}`);
   };
 
+  const openQuickPurchase = async (
+    e: React.MouseEvent,
+    product: FavoriteProduct,
+  ) => {
+    e.stopPropagation();
+
+    try {
+      const { data: response } = await axios.get(
+        `/api/products/${product.slug}`,
+      );
+      setSelectedProduct(response.data); // response.data is the actual product
+    } catch {
+      setSelectedProduct({ ...product, allergens: [], description: "" } as any);
+    }
+
+    setSelectedQuantity(1);
+    setIsDrawerOpen(true);
+  };
+
+  const handleAddToCartFromDrawer = (
+    product: FavoriteProduct,
+    quantity: number,
+  ) => {
+    addToCart({ ...product, price: Number(product.price) }, quantity);
+    setSelectedProduct(product);
+    setIsDrawerOpen(false);
+    setShowDialog(true);
+    setTimeout(() => setShowDialog(false), 3000);
+  };
+
+  const allergenIcons = {
+    Nuts: <Bean size={16} className="text-yellow-600" />,
+    Gluten: <Wheat size={16} className="text-yellow-600" />,
+    Eggs: <Egg size={16} className="text-yellow-600" />,
+    Dairy: <Milk size={16} className="text-yellow-600" />,
+  };
+
   return (
-    <ul className="grid grid-cols-2 md:grid-cols-4 gap-3 lg:gap-4 my-2 lg:my-4">
-      {products.map((item) => (
-        <div
-          onClick={() => handleProductClick(item.slug)}
-          key={item.product_id}
-          className="drawer-content drawer cursor-pointer group border border-gray-200 rounded-xl overflow-hidden relative hover:shadow-lg transition-shadow duration-200"
-        >
-          <div className="relative h-25 lg:h-52 bg-gray-100">
-            <Image
-              src={`${item.image_url}?t=${Date.now()}`}
-              alt={item.name}
-              className="relative h-full w-full object-cover transition-all duration-200"
-              sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
-              width={400}
-              height={300}
-            />
-          </div>
+    <div className="drawer drawer-end">
+      {/* Drawer toggle input */}
+      <input
+        id="cart-drawer"
+        type="checkbox"
+        className="drawer-toggle hidden"
+      />
+      {isDrawerOpen && (
+        <label
+          htmlFor="cart-drawer"
+          className="drawer-overlay fixed top-0 left-0 w-screen h-screen bg-black/50  z-50"
+          onClick={() => setIsDrawerOpen(false)}
+        ></label>
+      )}
 
-          <div className="p-4 relative">
-            <div className="flex flex-col lg:flex-row justify-between">
-              <h3 className="font-bold text-[0.95rem] text-yellow-600 truncate">
-                {item.name}
-              </h3>
+      {/* Drawer content */}
 
-              <span className="text-[0.95rem] font-semibold  text-green-600">
-                ${Number(item.price).toFixed(2)}
-              </span>
+      <ul className="grid grid-cols-2 md:grid-cols-4 gap-3 lg:gap-4 my-2 lg:my-4 drawer-content drawer">
+        {products.map((item) => (
+          <div
+            onClick={() => handleProductClick(item.slug)}
+            key={item.product_id}
+            className="drawer-content drawer cursor-pointer group border border-gray-200 rounded-xl overflow-hidden relative hover:shadow-lg transition-shadow duration-200"
+          >
+            <div className="relative h-25 lg:h-52 bg-gray-100">
+              <Image
+                src={`${item.image_url}?t=${Date.now()}`}
+                alt={item.name}
+                className="relative h-full w-full object-cover transition-all duration-200"
+                sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
+                width={400}
+                height={300}
+              />
             </div>
 
-            <div className="mt-3 flex gap-2">
-              <label htmlFor="cart-drawer" className="cursor-pointer w-full">
-                <Button
-                  size="sm"
-                  variant="yellow"
-                  className="flex-1 rounded-full text-xs w-full"
-                >
-                  Add to Cart
+            <div className="p-4 relative">
+              <div className="flex flex-col lg:flex-row justify-between">
+                <h3 className="font-bold text-[0.95rem] text-yellow-600 truncate">
+                  {item.name}
+                </h3>
+
+                <span className="text-[0.95rem] font-semibold  text-green-600">
+                  ${Number(item.price).toFixed(2)}
+                </span>
+              </div>
+
+              <div className="mt-3 flex gap-2">
+                <label htmlFor="cart-drawer" className="cursor-pointer w-full">
+                  <Button
+                    size="sm"
+                    variant="yellow"
+                    className="flex-1 rounded-full text-xs w-full"
+                    onClick={(e) => openQuickPurchase(e, item)}
+                  >
+                    Add to Cart
+                  </Button>
+                </label>
+                <Button variant="ghost" size="icon-sm">
+                  <Heart
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      removeFavorite(item.product_id);
+                    }}
+                    className={`transition-colors duration-200 ${
+                      isFavorite(item.product_id)
+                        ? "text-yellow-400"
+                        : "text-gray-300"
+                    }`}
+                    fill={isFavorite(item.product_id) ? "currentColor" : "none"}
+                  />
                 </Button>
-              </label>
-              <Button variant="ghost" size="icon-sm">
-                <Heart
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    removeFavorite(item.product_id);
-                  }}
-                  className={`transition-colors duration-200 ${
-                    isFavorite(item.product_id)
-                      ? "text-yellow-400"
-                      : "text-gray-300"
-                  }`}
-                  fill={isFavorite(item.product_id) ? "currentColor" : "none"}
-                />
-              </Button>
+              </div>
             </div>
           </div>
-        </div>
-      ))}
-    </ul>
+        ))}
+      </ul>
+      {selectedProduct && (
+        <DrawerPanel
+          selectedProduct={selectedProduct as any} // cast if DrawerPanel expects full Product type
+          isDrawerOpen={isDrawerOpen}
+          setIsDrawerOpen={setIsDrawerOpen}
+          selectedQuantity={selectedQuantity}
+          setSelectedQuantity={setSelectedQuantity}
+          handleAddToCartFromDrawer={(product, quantity) =>
+            handleAddToCartFromDrawer(product as FavoriteProduct, quantity)
+          }
+          allergenIcons={allergenIcons}
+          tabContent={{
+            Ingredients: "No ingredients info",
+            Allergens: "No allergens info",
+          }}
+        />
+      )}
+
+      {selectedProduct && (
+        <AddToCartDialog
+          isOpen={showDialog}
+          onClose={() => setShowDialog(false)}
+          productName={selectedProduct.name}
+          productImage={selectedProduct.image_url}
+          quantity={selectedQuantity}
+          price={Number(selectedProduct.price ?? 0)}
+        />
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
## Pull Request

This pull request introduces the following changes:

### Features / Updates

**Cart Page**
- Redesign cart page with responsive two-column desktop layout and sticky order summary sidebar
- Add mobile sticky footer with subtotal, delivery fee, and checkout button
- Add free shipping threshold logic ($50) with progress messaging
- Show delivery fee ($15) or FREE based on cart total
- Add "Continue Shopping" link on both mobile and desktop

**Cart Items**
- Add swipe-to-delete gesture for mobile cart items
- Add favorites toggle (save for later / in favorites) per item
- Add item count display in cart header
- Add scrollable cart item list with sticky table header on desktop